### PR TITLE
Ensures MLAlertView is centered properly.

### DIFF
--- a/MLAlertView/MLAlertView.m
+++ b/MLAlertView/MLAlertView.m
@@ -199,7 +199,7 @@
         CGRect boundingRect = [message boundingRectWithSize:maximumSize options:NSStringDrawingUsesLineFragmentOrigin attributes:@{ NSFontAttributeName : font} context:nil];
         CGFloat height = boundingRect.size.height + 16.0+40+extraHeight;
         
-        _alertView = [[UIView alloc] initWithFrame:CGRectMake(20, (screenHeight-height)/2, kAlertwidth, height)];
+        _alertView = [[UIView alloc] initWithFrame:CGRectMake((screenWidth-kAlertwidth)/2, (screenHeight-height)/2, kAlertwidth, height)];
         _alertView.backgroundColor = [UIColor whiteColor];
         _alertView.layer.masksToBounds = YES;
         _alertView.layer.cornerRadius = 13;


### PR DESCRIPTION
Ensures MLAlertView is centered properly. Component not previously centering when width of device was > 320 (eg. iPhone 6, iPhone 6 Plus).
